### PR TITLE
Add batch JSON logging for depersonalization runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Features:
 * Settings stored in `wa_app_settings`.
 
 * All runs write to `wa-log/depersonalizer.log`.
-=======
-* Logs operations into `wa-log/depersonalizer.log`.
+* Batch details saved as JSON under `wa-log/depersonalizer/YYYY-MM-DD/`.
 
 
 > **Warning:** This is a simplified implementation for demo purposes. UI and

--- a/lib/shopDepersonalizerPlugin.class.php
+++ b/lib/shopDepersonalizerPlugin.class.php
@@ -41,6 +41,29 @@ class shopDepersonalizerPlugin extends shopPlugin
     }
 
     /**
+     * Save batch processing details to dated JSON log file.
+     *
+     * @param array $data Arbitrary batch information
+     * @return string Absolute path to created log file
+     */
+    public function logBatch(array $data)
+    {
+        $root = wa()->getConfig()->getRootPath();
+        $dir  = $root.'/wa-log/depersonalizer/'.date('Y-m-d');
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $file = $dir.'/batch-'.date('H-i-s').'.json';
+        $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        file_put_contents($file, $json);
+
+        // keep reference to log file in main plugin log
+        waLog::log('Batch log created: '.$file, self::LOG_FILE);
+
+        return $file;
+    }
+
+    /**
      * Add plugin link to backend menu
      *
      * @param array $menu


### PR DESCRIPTION
## Summary
- add dated JSON batch logs under `wa-log/depersonalizer/`
- collect processed and skipped IDs during CLI runs and record log paths
- document new logging location

## Testing
- `php -l lib/shopDepersonalizerPlugin.class.php`
- `php -l lib/cli/Depersonalizer.cli.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb01fa28832890ec579c1bff2ce4