### PR TITLE
feat: allow geo retention and contact ID anonymization

### DIFF
--- a/lib/shopDepersonalizerPlugin.class.php
+++ b/lib/shopDepersonalizerPlugin.class.php
@@ -31,6 +31,27 @@ class shopDepersonalizerPlugin extends shopPlugin
     }
 
     /**
+     * Return ID of anonymous contact, creating one if needed.
+     *
+     * @return int
+     */
+    public function getAnonContactId()
+    {
+        $app_settings_model = new waAppSettingsModel();
+        $cid = $app_settings_model->get('shop', 'depersonalizer.anon_contact_id');
+        if ($cid) {
+            return (int)$cid;
+        }
+        $contact = new waContact();
+        $contact['firstname'] = _wp('Anonymous');
+        $contact['lastname']  = _wp('Customer');
+        $contact->save();
+        $cid = $contact->getId();
+        $app_settings_model->set('shop', 'depersonalizer.anon_contact_id', $cid);
+        return (int)$cid;
+    }
+
+    /**
      * Write message to plugin log
      *
      * @param string $message


### PR DESCRIPTION
## Summary
- copy geo fields into `geo_*` params when keeping location data
- swap order `contact_id` with persistent anonymous contact
- add helper for storing/creating anonymous contact in settings

## Testing
- `php -l lib/cli/Depersonalizer.cli.php`
- `php -l lib/shopDepersonalizerPlugin.class.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdca8e23dc832890dd23a3ec2ce5ef