### PR TITLE
Expand PII key coverage and pattern detection

### DIFF
--- a/lib/cli/Depersonalizer.cli.php
+++ b/lib/cli/Depersonalizer.cli.php
@@ -78,8 +78,7 @@ class shopDepersonalizerCli extends waCliController
                 if (in_array($k, array('depersonalized', 'depersonalized_at'))) {
                     continue;
                 }
-                $is_pii = in_array($k, $plugin->getPIIKeys()) || preg_match('/(name|email|phone|address|zip|city|region|street|house)/i', $k);
-                if (!$is_pii) {
+                if (!$plugin->isPIIKey($k)) {
                     continue;
                 }
                 $params_model->set($o['id'], $k, $this->maskParam($k, $v, $o['id']));
@@ -139,20 +138,16 @@ class shopDepersonalizerCli extends waCliController
      */
     protected function maskParam($key, $value, $order_id)
     {
-        switch ($key) {
-            case 'email':
-                return 'anon+'.$order_id.'@example.invalid';
-            case 'phone':
-                return 'anon-'.sha1($order_id);
-            case 'firstname':
-            case 'middlename':
-            case 'lastname':
-            case 'name':
-            case 'company':
-                return _wp('Удалено');
-            default:
-                return '';
+        if (preg_match('/email/i', $key)) {
+            return 'anon+'.$order_id.'@example.invalid';
         }
+        if (preg_match('/phone/i', $key)) {
+            return 'anon-'.sha1($order_id);
+        }
+        if (preg_match('/(firstname|middlename|lastname|name|company)/i', $key)) {
+            return _wp('Удалено');
+        }
+        return '';
     }
 
     /**
@@ -169,7 +164,6 @@ class shopDepersonalizerCli extends waCliController
         } catch (Exception $e) {
             // ignore logging errors but still output to console
         }
-=======
         echo date('[Y-m-d H:i:s] ') . $msg . "\n";
     }
 }

--- a/lib/shopDepersonalizerPlugin.class.php
+++ b/lib/shopDepersonalizerPlugin.class.php
@@ -15,10 +15,30 @@ class shopDepersonalizerPlugin extends shopPlugin
      */
     protected $pii_keys = array(
         'firstname', 'middlename', 'lastname', 'name', 'company',
-        'email', 'phone', 'shipping_address', 'billing_address',
+        'email', 'phone',
+        'shipping_address', 'billing_address',
         'address', 'zip', 'city', 'region', 'street', 'house',
-        'customer_comment', 'comment', 'ip', 'user_agent'
+        'customer_comment', 'comment', 'ip', 'user_agent',
+        // shipping details
+        'shipping_firstname', 'shipping_middlename', 'shipping_lastname',
+        'shipping_name', 'shipping_company', 'shipping_email', 'shipping_phone',
+        'shipping_zip', 'shipping_city', 'shipping_region', 'shipping_street', 'shipping_house',
+        // billing details
+        'billing_firstname', 'billing_middlename', 'billing_lastname',
+        'billing_name', 'billing_company', 'billing_email', 'billing_phone',
+        'billing_zip', 'billing_city', 'billing_region', 'billing_street', 'billing_house'
     );
+
+    /**
+     * Determine if given key contains PII
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function isPIIKey($key)
+    {
+        return in_array($key, $this->pii_keys) || preg_match('/(name|email|phone|address|zip|city|region|street|house)/i', $key);
+    }
 
     /**
      * Return list of PII keys. Allows extensions via hook.


### PR DESCRIPTION
## Summary
- extend default PII key registry with shipping/billing parameters
- add pattern-based PII detection helper and use it when depersonalizing orders
- mask matched parameters with regex-based logic for consistent anonymization

## Testing
- `php -l lib/shopDepersonalizerPlugin.class.php`
- `php -l lib/cli/Depersonalizer.cli.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdcae8b2648328b405d56159dc97d1