### PR TITLE
Process depersonalization orders in batches

### DIFF
--- a/lib/cli/Depersonalizer.cli.php
+++ b/lib/cli/Depersonalizer.cli.php
@@ -31,25 +31,49 @@ class shopDepersonalizerCli extends waCliController
         $this->log("Starting depersonalization for orders before {$cutoff}. Mode: " . ($dry_run ? 'dry-run' : 'apply'));
 
         $order_model = new shopOrderModel();
-        $orders = $order_model->select('id, contact_id')->where('create_datetime < ?', $cutoff)->fetchAll();
-        $this->log("Found old orders: " . count($orders));
+        $total = (int)$order_model
+            ->query(
+                "SELECT COUNT(*) cnt FROM shop_order WHERE create_datetime < s:cutoff",
+                ['cutoff' => $cutoff]
+            )
+            ->fetchField();
+        $this->log("Found old orders: ".$total);
 
-        if (!$dry_run) {
-            $this->processOrders($orders, $keep_geo, $wipe_comments, $anonymize_contact_id);
-            $this->processContacts($orders, $cutoff);
+        if ($dry_run) {
+            $this->log('Dry-run mode. No data will be modified.');
+        } else {
+            $limit = 500;
+            $offset = 0;
+            $processed = 0;
+            while (true) {
+                $orders = $order_model
+                    ->query(
+                        "SELECT id, contact_id FROM shop_order WHERE create_datetime < s:cutoff ORDER BY id LIMIT i:limit OFFSET i:offset",
+                        ['cutoff' => $cutoff, 'limit' => $limit, 'offset' => $offset]
+                    )
+                    ->fetchAll();
+                if (!$orders) {
+                    break;
+                }
+                $this->processOrders($orders, $keep_geo, $wipe_comments, $anonymize_contact_id);
+                $this->processContacts($orders, $cutoff);
+
+                $processed += count($orders);
+                $this->log("Processed {$processed}/{$total}");
+
+                $offset += $limit;
+                unset($orders);
+                if (function_exists('gc_collect_cycles')) {
+                    gc_collect_cycles();
+                }
+            }
 
             $plugin = wa('shop')->getPlugin('depersonalizer');
             if ($plugin && method_exists($plugin, 'logBatch')) {
-                $path = $plugin->logBatch(array(
-                    'orders'   => array(
-                        'processed' => $this->processed_orders,
-                        'skipped'   => $this->skipped_orders,
-                    ),
-                    'contacts' => array(
-                        'processed' => $this->processed_contacts,
-                        'skipped'   => $this->skipped_contacts,
-                    ),
-                ));
+                $path = $plugin->logBatch([
+                    'orders'   => ['processed' => $this->processed_orders, 'skipped' => $this->skipped_orders],
+                    'contacts' => ['processed' => $this->processed_contacts, 'skipped' => $this->skipped_contacts],
+                ]);
                 $this->log('Batch details saved to '.$path);
             }
         }


### PR DESCRIPTION
## Summary
- Count old orders and skip modifications in dry-run mode
- Process orders in batches with progress logging and GC
- Log batch details after processing

## Testing
- `php -l lib/cli/Depersonalizer.cli.php`


------
https://chatgpt.com/codex/tasks/task_e_68c67625b97c8328a571ffdb9739e023