### PR TITLE
Add batch depersonalization run controller and UI

### DIFF
--- a/lib/actions/backend/shopDepersonalizerPluginBackendList.action.php
+++ b/lib/actions/backend/shopDepersonalizerPluginBackendList.action.php
@@ -6,10 +6,44 @@ class shopDepersonalizerPluginBackendListAction extends waViewAction
 {
     public function execute()
     {
-        $plugin = wa('shop')->getPlugin('depersonalizer');
+        // Only users with shop settings rights may run depersonalization
+        if (!wa()->getUser()->getRights('shop', 'settings')) {
+            throw new waRightsException(_w('Access denied'));
+        }
+
+        $plugin   = wa('shop')->getPlugin('depersonalizer');
         $settings = $plugin->getSettings();
+
+        // Build form controls for template
+        $fields = array(
+            'days' => waHtmlControl::getControl(waHtmlControl::INPUT, array(
+                'name'  => 'days',
+                'id'    => 'days',
+                'value' => (int) ifset($settings['retention_days'], 365),
+            )),
+            'keep_geo' => waHtmlControl::getControl(waHtmlControl::CHECKBOX, array(
+                'name'    => 'keep_geo',
+                'id'      => 'keep_geo',
+                'value'   => 1,
+                'checked' => !empty($settings['keep_geo']),
+            )),
+            'wipe_comments' => waHtmlControl::getControl(waHtmlControl::CHECKBOX, array(
+                'name'    => 'wipe_comments',
+                'id'      => 'wipe_comments',
+                'value'   => 1,
+                'checked' => !empty($settings['wipe_comments']),
+            )),
+            'anonymize_contact_id' => waHtmlControl::getControl(waHtmlControl::CHECKBOX, array(
+                'name'    => 'anonymize_contact_id',
+                'id'      => 'anonymize_contact_id',
+                'value'   => 1,
+                'checked' => !empty($settings['anonymize_contact_id']),
+            )),
+        );
+
         $this->view->assign(array(
             'settings' => $settings,
+            'fields'   => $fields,
             'message'  => _wp('Configure depersonalization and run below.'),
         ));
     }

--- a/lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php
+++ b/lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Render progress page and kick off depersonalization.
+ */
+class shopDepersonalizerPluginBackendRunAction extends waViewAction
+{
+    public function execute()
+    {
+        // Rights and CSRF checks
+        if (!wa()->getUser()->getRights('shop', 'settings')) {
+            throw new waRightsException(_w('Access denied'));
+        }
+        $csrf = waRequest::post('_csrf', '', waRequest::TYPE_STRING);
+        if (!$csrf || $csrf !== wa()->getCSRFToken()) {
+            throw new waException('CSRF token invalid');
+        }
+
+        $options = array(
+            'days'                 => waRequest::post('days', 365, waRequest::TYPE_INT),
+            'keep_geo'             => waRequest::post('keep_geo', 0, waRequest::TYPE_INT),
+            'wipe_comments'        => waRequest::post('wipe_comments', 0, waRequest::TYPE_INT),
+            'anonymize_contact_id' => waRequest::post('anonymize_contact_id', 0, waRequest::TYPE_INT),
+            '_csrf'                => $csrf,
+        );
+
+        $this->view->assign('options', $options);
+    }
+}

--- a/templates/actions/backend/list.html
+++ b/templates/actions/backend/list.html
@@ -5,16 +5,16 @@
     <form id="depersonalizer-form" method="post">
         <div class="field">
             <div class="name"><label for="days">{_wp('Retention days')}</label></div>
-            <div class="value"><input type="number" name="days" id="days" value="{$settings.retention_days}"></div>
+            <div class="value">{$fields.days}</div>
         </div>
         <div class="field">
-            <div class="value"><label><input type="checkbox" name="keep_geo" value="1"{if $settings.keep_geo} checked{/if}> {_wp('Keep geo statistics')}</label></div>
+            <div class="value"><label>{$fields.keep_geo} {_wp('Keep geo statistics')}</label></div>
         </div>
         <div class="field">
-            <div class="value"><label><input type="checkbox" name="wipe_comments" value="1"{if $settings.wipe_comments} checked{/if}> {_wp('Wipe order comments')}</label></div>
+            <div class="value"><label>{$fields.wipe_comments} {_wp('Wipe order comments')}</label></div>
         </div>
         <div class="field">
-            <div class="value"><label><input type="checkbox" name="anonymize_contact_id" value="1"{if $settings.anonymize_contact_id} checked{/if}> {_wp('Replace contact_id with anonymous contact')}</label></div>
+            <div class="value"><label>{$fields.anonymize_contact_id} {_wp('Replace contact_id with anonymous contact')}</label></div>
         </div>
         {$wa->csrf()}
         <div class="field">
@@ -32,8 +32,8 @@
 (function($) {
     var form = $('#depersonalizer-form');
     var output = $('#depersonalizer-output');
-    function send(action) {
-        $.post('?plugin=depersonalizer&module=run&action=' + action, form.serialize(), function(resp) {
+    function preview() {
+        $.post('?plugin=depersonalizer&module=run&action=preview', form.serialize(), function(resp) {
             if (resp && resp.data && resp.data.message) {
                 output.text(resp.data.message);
             } else if (resp && resp.message) {
@@ -43,7 +43,9 @@
             }
         }, 'json');
     }
-    form.find('.preview').on('click', function() { send('preview'); });
-    form.find('.run').on('click', function() { send('run'); });
+    form.find('.preview').on('click', preview);
+    form.find('.run').on('click', function() {
+        output.load('?plugin=depersonalizer&action=run', form.serialize());
+    });
 })(jQuery);
 </script>

--- a/templates/actions/backend/run.html
+++ b/templates/actions/backend/run.html
@@ -1,0 +1,43 @@
+<div class="block" id="depersonalizer-run">
+    <h1>AnonGuard</h1>
+    <div class="progressbar" style="height:20px;">
+        <div class="bar" style="width:0%;"></div>
+    </div>
+    <p class="progress-text"></p>
+</div>
+<script type="text/javascript">
+(function($) {
+    var opts = {
+        days: {$options.days|escape:'javascript'},
+        keep_geo: {$options.keep_geo|escape:'javascript'},
+        wipe_comments: {$options.wipe_comments|escape:'javascript'},
+        anonymize_contact_id: {$options.anonymize_contact_id|escape:'javascript'},
+        _csrf: '{$options._csrf|escape:'javascript'}'
+    };
+    var offset = 0;
+    var limit = 50;
+    var bar = $('#depersonalizer-run .bar');
+    var text = $('#depersonalizer-run .progress-text');
+    function step() {
+        var data = $.extend({}, opts, {offset: offset, limit: limit});
+        $.post('?plugin=depersonalizer&module=run&action=run', data, function(resp) {
+            if (resp.status === 'ok') {
+                var d = resp.data;
+                offset = d.offset;
+                var percent = d.total ? Math.round(offset / d.total * 100) : 100;
+                if (percent > 100) { percent = 100; }
+                bar.css('width', percent + '%');
+                if (d.done) {
+                    text.text(d.message || '');
+                } else {
+                    text.text(offset + ' / ' + d.total);
+                    step();
+                }
+            } else {
+                text.text(resp.error || 'Error');
+            }
+        }, 'json');
+    }
+    step();
+})(jQuery);
+</script>


### PR DESCRIPTION
## Summary
- build list action with rights check and HTML form helpers
- implement batch depersonalization controller returning JSON progress
- add run action/template with progress bar and AJAX-driven execution

## Testing
- `php -l webasyst-depersonalizer/lib/actions/backend/shopDepersonalizerPluginBackendList.action.php`
- `php -l webasyst-depersonalizer/lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php`
- `php -l webasyst-depersonalizer/lib/actions/backend/BackendRun.controller.php`


------
https://chatgpt.com/codex/tasks/task_e_68c69c22c82c8328b99540c825280f1d