### PR TITLE
feat: support geo retention and contact anonymization

### DIFF
--- a/lib/actions/backend/BackendRun.controller.php
+++ b/lib/actions/backend/BackendRun.controller.php
@@ -145,19 +145,21 @@ class shopDepersonalizerPluginBackendRunController extends waJsonController
 
     protected function maskParam($key, $value, $order_id)
     {
-        switch ($key) {
-            case 'email':
-                return 'anon+'.$order_id.'@example.invalid';
-            case 'phone':
-                return 'anon-'.sha1($order_id);
-            case 'firstname':
-            case 'middlename':
-            case 'lastname':
-            case 'name':
-            case 'company':
-                return _wp('Удалено');
-            default:
-                return '';
+        if (preg_match('/email/i', $key)) {
+            return 'anon+'.$order_id.'@example.invalid';
         }
+        if (preg_match('/phone/i', $key)) {
+            return 'anon-'.sha1($order_id);
+        }
+        if (preg_match('/(firstname|middlename|lastname|name|company)/i', $key)) {
+            return _wp('Удалено');
+        }
+        if (preg_match('/ip/i', $key)) {
+            return '0.0.0.0';
+        }
+        if (preg_match('/user_agent/i', $key)) {
+            return 'unknown';
+        }
+        return '';
     }
 }

--- a/lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php
+++ b/lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php
@@ -23,6 +23,12 @@ class shopDepersonalizerPluginBackendRunAction extends waViewAction
             'exclude'              => waRequest::post('exclude', array()),
             '_csrf'                => $csrf,
         );
+        $settings_model = new waAppSettingsModel();
+        $settings_model->set('shop', 'depersonalizer.retention_days', $options['days']);
+        $settings_model->set('shop', 'depersonalizer.keep_geo', (int)$options['keep_geo']);
+        $settings_model->set('shop', 'depersonalizer.wipe_comments', (int)$options['wipe_comments']);
+        $settings_model->set('shop', 'depersonalizer.anonymize_contact_id', (int)$options['anonymize_contact_id']);
+        $settings_model->set('shop', 'depersonalizer.last_run_at', date('Y-m-d H:i:s'));
 
         $this->view->assign('options', $options);
     }


### PR DESCRIPTION
## Summary
- copy country/region/city to geo_* when keeping geo data and mask address fields
- optionally replace order contact_id with configured anonymous contact
- persist depersonalization options and update anonymization mask

## Testing
- `php -l lib/cli/Depersonalizer.cli.php`
- `php -l lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php`
- `php -l lib/actions/backend/BackendRun.controller.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6a1510a5883289e41e85e9fca00d1