### PR TITLE
feat: process batches with transactions

### DIFF
--- a/lib/cli/Depersonalizer.cli.php
+++ b/lib/cli/Depersonalizer.cli.php
@@ -52,29 +52,39 @@ class shopDepersonalizerCli extends waCliController
             $offset = 0;
             $processed = 0;
             while (true) {
-                $orders = $order_model
-                    ->query(
-                        "SELECT id, contact_id FROM shop_order WHERE create_datetime < s:cutoff ORDER BY id LIMIT i:limit OFFSET i:offset",
-                        array(
-                            'cutoff' => $cutoff,
-                            'limit'  => $limit,
-                            'offset' => $offset,
-                        )
+                $result = $order_model->query(
+                    "SELECT id, contact_id FROM shop_order WHERE create_datetime < s:cutoff ORDER BY id LIMIT i:limit OFFSET i:offset",
+                    array(
+                        'cutoff' => $cutoff,
+                        'limit'  => $limit,
+                        'offset' => $offset,
                     )
-                    ->fetchAll();
+                );
+
+                $orders = array();
+                while ($row = $result->fetchAssoc()) {
+                    $orders[] = $row;
+                }
 
                 if (!$orders) {
                     break;
                 }
 
-                $this->processOrders($orders, $keep_geo, $wipe_comments, $anonymize_contact_id);
-                $this->processContacts($orders, $cutoff);
+                $order_model->exec('START TRANSACTION');
+                try {
+                    $this->processOrders($orders, $keep_geo, $wipe_comments, $anonymize_contact_id);
+                    $this->processContacts($orders, $cutoff);
+                    $order_model->exec('COMMIT');
+                } catch (Exception $e) {
+                    $order_model->exec('ROLLBACK');
+                    throw $e;
+                }
 
                 $processed += count($orders);
                 $this->log("Processed {$processed}/{$total}");
 
                 $offset += $limit;
-                unset($orders);
+                unset($orders, $result);
                 if (function_exists('gc_collect_cycles')) {
                     gc_collect_cycles();
                 }


### PR DESCRIPTION
## Summary
- process depersonalization batches within a transaction
- stream query results in smaller chunks

## Testing
- `php -l lib/cli/Depersonalizer.cli.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6a6ba0b208328b2088c6a1ed0c706