### PR TITLE
Enable excluding detected keys before depersonalization run

### DIFF
--- a/lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php
+++ b/lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php
@@ -20,7 +20,7 @@ class shopDepersonalizerPluginBackendRunAction extends waViewAction
             'keep_geo'             => waRequest::post('keep_geo', 0, waRequest::TYPE_INT),
             'wipe_comments'        => waRequest::post('wipe_comments', 0, waRequest::TYPE_INT),
             'anonymize_contact_id' => waRequest::post('anonymize_contact_id', 0, waRequest::TYPE_INT),
-            'exclude'              => waRequest::post('exclude', array()),
+            'keys'                 => waRequest::post('keys', array()),
             '_csrf'                => $csrf,
         );
         $settings_model = new waAppSettingsModel();

--- a/templates/actions/backend/list.html
+++ b/templates/actions/backend/list.html
@@ -48,7 +48,7 @@
                 if (resp.data.keys && resp.data.keys.length) {
                     var html = '';
                     $.each(resp.data.keys, function(i, k) {
-                        html += '<label><input type="checkbox" name="exclude[]" value="' + k + '"> ' + k + '</label><br>';
+                        html += '<label><input type="checkbox" name="keys[]" value="' + k + '" checked> ' + k + '</label><br>';
                     });
                     keys_container.html(html);
                     keys_wrapper.show();

--- a/templates/actions/backend/run.html
+++ b/templates/actions/backend/run.html
@@ -12,7 +12,7 @@
         keep_geo: {$options.keep_geo|escape:'javascript'},
         wipe_comments: {$options.wipe_comments|escape:'javascript'},
         anonymize_contact_id: {$options.anonymize_contact_id|escape:'javascript'},
-        exclude: {$options.exclude|@json_encode},
+        keys: {$options.keys|@json_encode},
         _csrf: '{$options._csrf|escape:'javascript'}'
     };
     var offset = 0;


### PR DESCRIPTION
## Summary
- Preselect all detected PII keys in preview so admins can uncheck keys to skip
- Pass selected keys through run action and limit depersonalization to them

## Testing
- `php -l lib/actions/backend/shopDepersonalizerPluginBackendRun.action.php`
- `php -l lib/actions/backend/BackendRun.controller.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6acb1fc048328a6225930e356b160