### PR TITLE
Persist path to depersonalization batch logs

### DIFF
--- a/lib/config/install.php
+++ b/lib/config/install.php
@@ -14,6 +14,7 @@ class shopDepersonalizerPluginInstall
             'depersonalizer.anonymize_contact_id' => 0,
             'depersonalizer.anon_contact_id'    => null,
             'depersonalizer.last_run_at'        => null,
+            'depersonalizer.last_log_path'      => null,
         );
         foreach ($defaults as $key => $value) {
             if ($app_settings_model->get('shop', $key) === null) {

--- a/lib/config/uninstall.php
+++ b/lib/config/uninstall.php
@@ -14,6 +14,7 @@ class shopDepersonalizerPluginUninstall
             'depersonalizer.anonymize_contact_id',
             'depersonalizer.anon_contact_id',
             'depersonalizer.last_run_at',
+            'depersonalizer.last_log_path',
         );
         foreach ($keys as $key) {
             $app_settings_model->del('shop', $key);

--- a/lib/shopDepersonalizerPlugin.class.php
+++ b/lib/shopDepersonalizerPlugin.class.php
@@ -121,6 +121,10 @@ class shopDepersonalizerPlugin extends shopPlugin
         // keep reference to log file in main plugin log
         waLog::log('Batch log created: '.$file, self::LOG_FILE);
 
+        // remember path to last log file in settings
+        $settings_model = new waAppSettingsModel();
+        $settings_model->set('shop', 'depersonalizer.last_log_path', $file);
+
         return $file;
     }
 


### PR DESCRIPTION
## Summary
- Save path to latest depersonalization batch log in plugin settings
- Include log path setting in install/uninstall scripts

## Testing
- `php -l lib/shopDepersonalizerPlugin.class.php`
- `php -l lib/config/install.php`
- `php -l lib/config/uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6af23f13c83288fb9fff82a618d6b