### PR TITLE
Expand geo retention and contact anonymization

### DIFF
--- a/lib/config/settings.php
+++ b/lib/config/settings.php
@@ -19,6 +19,7 @@ return array(
     ),
     'anonymize_contact_id' => array(
         'title'        => _wp('Replace contact_id with anonymous contact'),
+        'description'  => _wp('Store depersonalized orders under a special anonymous contact.'),
         'value'        => 0,
         'control_type' => waHtmlControl::CHECKBOX,
     ),

--- a/lib/shopDepersonalizerPlugin.class.php
+++ b/lib/shopDepersonalizerPlugin.class.php
@@ -17,7 +17,7 @@ class shopDepersonalizerPlugin extends shopPlugin
         'firstname', 'middlename', 'lastname', 'name', 'company',
         'email', 'phone',
         'shipping_address', 'billing_address',
-        'address', 'zip', 'city', 'region', 'street', 'house',
+        'address', 'zip', 'city', 'region', 'country', 'street', 'house',
         'customer_comment', 'comment', 'ip', 'user_agent',
         // shipping details
         'shipping_firstname', 'shipping_middlename', 'shipping_lastname',
@@ -39,7 +39,7 @@ class shopDepersonalizerPlugin extends shopPlugin
      */
     public function isPIIKey($key)
     {
-        return in_array($key, $this->pii_keys) || preg_match('/(name|email|phone|address|zip|city|region|street|house)/i', $key);
+        return in_array($key, $this->pii_keys) || preg_match('/(name|email|phone|address|zip|city|region|street|house|country)/i', $key);
     }
 
     /**
@@ -52,7 +52,7 @@ class shopDepersonalizerPlugin extends shopPlugin
     {
         $detected = array();
         foreach ($params as $k => $v) {
-            if (preg_match('/(name|email|phone|address|zip|city|region|street|house)/i', $k)) {
+            if (preg_match('/(name|email|phone|address|zip|city|region|street|house|country)/i', $k)) {
                 $detected[] = $k;
             }
         }


### PR DESCRIPTION
## Summary
- Preserve country, region and city values in `geo_*` order params when geo stats are kept
- Replace order `contact_id` with anonymous contact when anonymization is enabled
- Treat `country` as PII and document anonymous contact option in settings

## Testing
- `php -l lib/cli/Depersonalizer.cli.php`
- `php -l lib/config/settings.php`
- `php -l lib/shopDepersonalizerPlugin.class.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6ba62f9f48328885d384eb3183ed0